### PR TITLE
Cache vendor faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 sudo: false
 
+cache:
+  directories:
+    - vendor
+
 php:
   - 7.2
 

--- a/bin/browscap-site
+++ b/bin/browscap-site
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+ini_set('memory_limit', '-1');
+
 $autoloadPaths = array(
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../../../vendor/autoload.php',


### PR DESCRIPTION
Also force `memory_limit=-1` on CLI script to avoid Heroku deploy issue hopefully.